### PR TITLE
Update base image to  eclipse-temurin:17.0.19_10-jdk

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Upgrade Dockerfile for use kafka 4.3.1
+- Upgrade Dockerfile for use eclipse-temurin:17.0.19_10-jdk instead of openjdk:17.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with kafnus. If not, see http://www.gnu.org/licenses/.
 
-FROM openjdk:17.0.2-jdk-slim
+FROM eclipse-temurin:17.0.19_10-jdk
+
 
 ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with kafnus. If not, see http://www.gnu.org/licenses/.
 
-FROM openjdk:17.0.1-jdk-slim
+FROM openjdk:17.0.2-jdk-slim
 
 ARG KAFKA_VERSION=4.2.0
 ARG SCALA_VERSION=2.13


### PR DESCRIPTION
Not sure if more updated jdk is possible

openjdk 17.0.1 is from  October 19th 2021

Maybe other equivalent images could work: FROM eclipse-temurin:17-jdk https://hub.docker.com/layers/library/eclipse-temurin/17-jdk/images/sha256-f7b969d455abeefb9cad0280477e067d8340c22a081347a94c6fe22d0c67d420
