### PR TITLE
foce to use jammy image version (for dockerhub builds)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
 - Upgrade Dockerfile for use kafka 4.3.1
-- Upgrade Dockerfile for use eclipse-temurin:17.0.19_10-jdk instead of openjdk:17.0.1
+- Upgrade Dockerfile for use eclipse-temurin:17.0.19_10-jdk-jammy instead of openjdk:17.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with kafnus. If not, see http://www.gnu.org/licenses/.
 
-#FROM eclipse-temurin:17.0.19_10-jdk
-FROM eclipse-temurin:17-jdk-jammy
+FROM eclipse-temurin:17.0.19_10-jdk-jammy
 
 ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13
@@ -33,18 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## -----------------------------
 ## Download Kafka (official distribution)
 ## -----------------------------
-# RUN mkdir -p /tmp/test && \
-#     echo hola > /tmp/test/f1 && \
-#     echo hola > /tmp/test/f2 && \
-#     mkdir /tmp/test/d1 && \
-#     echo hola > /tmp/test/d1/f3
-
-# RUN curl -fsSL \
-#   "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
-#   -o /tmp/kafka.tgz && \
-#   tar -tzf /tmp/kafka.tgz | head -50
-
-
 RUN mkdir -p /tmp/kafka_extract && \
     curl -fsSL \
     "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with kafnus. If not, see http://www.gnu.org/licenses/.
 
-FROM eclipse-temurin:17.0.19_10-jdk
-
+#FROM eclipse-temurin:17.0.19_10-jdk
+FROM eclipse-temurin:17-jdk-jammy
 
 ARG KAFKA_VERSION=4.3.1
 ARG SCALA_VERSION=2.13
@@ -33,16 +33,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## -----------------------------
 ## Download Kafka (official distribution)
 ## -----------------------------
-RUN mkdir -p /tmp/test && \
-    echo hola > /tmp/test/f1 && \
-    echo hola > /tmp/test/f2 && \
-    mkdir /tmp/test/d1 && \
-    echo hola > /tmp/test/d1/f3
+# RUN mkdir -p /tmp/test && \
+#     echo hola > /tmp/test/f1 && \
+#     echo hola > /tmp/test/f2 && \
+#     mkdir /tmp/test/d1 && \
+#     echo hola > /tmp/test/d1/f3
 
-RUN curl -fsSL \
-  "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
-  -o /tmp/kafka.tgz && \
-  tar -tzf /tmp/kafka.tgz | head -50
+# RUN curl -fsSL \
+#   "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+#   -o /tmp/kafka.tgz && \
+#   tar -tzf /tmp/kafka.tgz | head -50
 
 
 RUN mkdir -p /tmp/kafka_extract && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## Download Kafka (official distribution)
 ## -----------------------------
 RUN mkdir -p /opt && \
+    touch /opt/test.txt && \
+    ls -l /opt && \
     cd /opt && \
     curl -fsSL "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
       -o /tmp/kafka.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## -----------------------------
 ## Download Kafka (official distribution)
 ## -----------------------------
-RUN mkdir -p /opt && \
-    touch /opt/test.txt && \
-    ls -l /opt && \
-    cd /opt && \
-    curl -fsSL "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
-      -o /tmp/kafka.tgz && \
-    tar -xzf /tmp/kafka.tgz -C /opt && \
+RUN mkdir -p /tmp/kafka_extract && \
+    curl -fsSL \
+    "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+-o /tmp/kafka.tgz && \
+    tar -xzf /tmp/kafka.tgz -C /tmp/kafka_extract && \
+    mv /tmp/kafka_extract/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/ && \
     ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME} && \
     rm /tmp/kafka.tgz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /opt && \
     touch /opt/test.txt && \
     ls -l /opt && \
     cd /opt && \
-    curl -fsSL "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+    curl -fsSL "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
       -o /tmp/kafka.tgz && \
     tar -xzf /tmp/kafka.tgz -C /opt && \
     ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## -----------------------------
 ## Download Kafka (official distribution)
 ## -----------------------------
+RUN mkdir -p /tmp/test && \
+    echo hola > /tmp/test/f1 && \
+    echo hola > /tmp/test/f2 && \
+    mkdir /tmp/test/d1 && \
+    echo hola > /tmp/test/d1/f3
+
+RUN curl -fsSL \
+  "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \
+  -o /tmp/kafka.tgz && \
+  tar -tzf /tmp/kafka.tgz | head -50
+
+
 RUN mkdir -p /tmp/kafka_extract && \
     curl -fsSL \
     "https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" \


### PR DESCRIPTION
Reopens https://github.com/telefonicaid/kafnus-connect/pull/61

Force to use jammy version to avoid errors in dockerhub build https://github.com/telefonicaid/kafnus-connect/